### PR TITLE
Fix: Remove duplicate useMemo import in Layout.tsx

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import {
   Calendar,


### PR DESCRIPTION
### Purpose

This pull request addresses a runtime error by removing a duplicate import statement.

### Code changes

- Removed the redundant `useMemo` import from `src/components/Layout.tsx`.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/ef44934bfe0046768f0b4bf2b565a0fb/stellar-space)

👀 [Preview Link](https://ef44934bfe0046768f0b4bf2b565a0fb-stellar-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>ef44934bfe0046768f0b4bf2b565a0fb</projectId>-->
<!--<branchName>stellar-space</branchName>-->