### PR TITLE
Feat: Add sponsors marquee and remove passport section

### DIFF
--- a/src/components/SponsorsMarquee.tsx
+++ b/src/components/SponsorsMarquee.tsx
@@ -1,0 +1,69 @@
+import { sponsors as defaultSponsors, type Sponsor } from "@/data/sponsors";
+import { cn } from "@/lib/utils";
+
+type SponsorsMarqueeProps = {
+  sponsors?: Sponsor[];
+  title?: string;
+  className?: string;
+};
+
+function Row({ items, reverse = false }: { items: Sponsor[]; reverse?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "flex min-w-max items-center gap-8 py-2",
+        reverse ? "animate-marquee-reverse" : "animate-marquee",
+      )}
+      aria-hidden
+    >
+      {[...items, ...items].map((s, idx) => (
+        <a
+          key={`${s.name}-${idx}`}
+          href={s.url}
+          target={s.url ? "_blank" : undefined}
+          rel={s.url ? "noopener noreferrer" : undefined}
+          className="group flex items-center gap-3 rounded-full border border-border/60 bg-background/70 px-5 py-2.5 shadow-sm backdrop-blur transition-colors hover:bg-background/90"
+        >
+          {s.logo ? (
+            <img
+              src={s.logo}
+              alt={s.name}
+              className="h-6 w-6 rounded-sm object-contain"
+              loading="lazy"
+              decoding="async"
+            />
+          ) : (
+            <span className="inline-flex h-6 w-6 items-center justify-center rounded-sm bg-primary/15 text-[10px] font-semibold uppercase tracking-wide text-primary">
+              {s.name.slice(0, 2)}
+            </span>
+          )}
+          <span className="text-sm font-medium text-foreground/80 group-hover:text-foreground">
+            {s.name}
+          </span>
+        </a>
+      ))}
+    </div>
+  );
+}
+
+export function SponsorsMarquee({ sponsors = defaultSponsors, title = "Patrocinadores", className }: SponsorsMarqueeProps) {
+  if (!sponsors || sponsors.length === 0) return null;
+
+  return (
+    <section className={cn("relative overflow-hidden", className)} aria-label={title}>
+      <div className="container mx-auto px-4">
+        <div className="mb-6 text-center">
+          <h3 className="text-xl font-semibold tracking-tight">{title}</h3>
+        </div>
+      </div>
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-r from-background via-transparent to-background" />
+      <div className="relative">
+        <div className="overflow-hidden">
+          <Row items={sponsors} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default SponsorsMarquee;

--- a/src/components/SponsorsMarquee.tsx
+++ b/src/components/SponsorsMarquee.tsx
@@ -7,7 +7,13 @@ type SponsorsMarqueeProps = {
   className?: string;
 };
 
-function Row({ items, reverse = false }: { items: Sponsor[]; reverse?: boolean }) {
+function Row({
+  items,
+  reverse = false,
+}: {
+  items: Sponsor[];
+  reverse?: boolean;
+}) {
   return (
     <div
       className={cn(
@@ -46,11 +52,18 @@ function Row({ items, reverse = false }: { items: Sponsor[]; reverse?: boolean }
   );
 }
 
-export function SponsorsMarquee({ sponsors = defaultSponsors, title = "Patrocinadores", className }: SponsorsMarqueeProps) {
+export function SponsorsMarquee({
+  sponsors = defaultSponsors,
+  title = "Patrocinadores",
+  className,
+}: SponsorsMarqueeProps) {
   if (!sponsors || sponsors.length === 0) return null;
 
   return (
-    <section className={cn("relative overflow-hidden", className)} aria-label={title}>
+    <section
+      className={cn("relative overflow-hidden", className)}
+      aria-label={title}
+    >
       <div className="container mx-auto px-4">
         <div className="mb-6 text-center">
           <h3 className="text-xl font-semibold tracking-tight">{title}</h3>

--- a/src/data/sponsors.ts
+++ b/src/data/sponsors.ts
@@ -1,0 +1,19 @@
+export type Sponsor = {
+  name: string;
+  url?: string;
+  logo?: string;
+  tier?: "ouro" | "prata" | "bronze" | "apoio";
+};
+
+export const sponsors: Sponsor[] = [
+  {
+    name: "TechCorp Solutions",
+    url: "https://techcorp.com.br",
+    tier: "ouro",
+  },
+  {
+    name: "DevTools Inc",
+    url: "https://devtools.com",
+    tier: "prata",
+  },
+];

--- a/src/pages/Ingresso.tsx
+++ b/src/pages/Ingresso.tsx
@@ -2,7 +2,7 @@ import { FormEvent, Fragment } from "react";
 import {
   ArrowRight,
   Calendar,
-  CheckCircle2,
+
   Clock,
   MapPin,
   Shield,
@@ -21,13 +21,6 @@ interface MarqueeImage {
   alt: string;
 }
 
-interface TicketTier {
-  name: string;
-  price: string;
-  description: string;
-  perks: string[];
-  highlight?: boolean;
-}
 
 const marqueeImages: MarqueeImage[] = [
   {
@@ -56,44 +49,6 @@ const marqueeImages: MarqueeImage[] = [
   },
 ];
 
-const ticketTiers: TicketTier[] = [
-  {
-    name: "Passaporte Comunidade",
-    price: "R$ 120",
-    description:
-      "Acesso completo aos três dias do FING com trilhas principais e lounges de networking.",
-    perks: [
-      "Acesso a todas as palestras e painéis",
-      "Sessões de matchmaking com mentores",
-      "Certificado digital de participação",
-    ],
-  },
-  {
-    name: "Passaporte Visionário",
-    price: "R$ 220",
-    description:
-      "Experiência imersiva com áreas VIP, mentorias exclusivas e fast-track nos principais espaços.",
-    perks: [
-      "Lounge VIP com cafés especiais",
-      "Sessão de mentoria com especialistas",
-      "Kit de boas-vindas personalizado",
-      "Reservas antecipadas em workshops",
-    ],
-    highlight: true,
-  },
-  {
-    name: "Passaporte Corporativo",
-    price: "Sob consulta",
-    description:
-      "Pacote para equipes e organizações que desejam acelerar projetos com benefícios personalizados.",
-    perks: [
-      "Credenciais para até 8 integrantes",
-      "Sessão estratégica com curadoria do FING",
-      "Branding em ambientes selecionados",
-      "Acesso às gravações pós-evento",
-    ],
-  },
-];
 
 const registrationBenefits = [
   {
@@ -307,58 +262,6 @@ export default function Ingresso() {
         </div>
       </section>
 
-      <section id="planos" className="relative bg-muted/40 py-24">
-        <div className="absolute inset-0 bg-gradient-to-b from-background via-transparent to-background/60" />
-        <div className="container relative mx-auto px-4">
-          <div className="mb-12 flex flex-col items-center text-center">
-            <h2 className="text-3xl font-bold md:text-4xl">
-              Escolha o passaporte ideal para sua jornada
-            </h2>
-            <p className="mt-4 max-w-2xl text-lg text-muted-foreground">
-              Cada modalidade foi pensada para garantir a melhor experiência de
-              acordo com seus objetivos no FING.
-            </p>
-          </div>
-
-          <div className="grid gap-8 lg:grid-cols-3">
-            {ticketTiers.map((tier) => (
-              <div
-                key={tier.name}
-                className={cn(
-                  "flex h-full flex-col rounded-3xl border border-border/70 bg-background/90 p-8 shadow-xl backdrop-blur transition-transform duration-300 hover:-translate-y-2",
-                  tier.highlight && "ring-2 ring-primary",
-                )}
-              >
-                <div className="space-y-3">
-                  <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
-                    {tier.name}
-                  </span>
-                  <p className="text-sm text-muted-foreground">
-                    {tier.description}
-                  </p>
-                </div>
-                <div className="mt-6 text-4xl font-bold text-foreground">
-                  {tier.price}
-                </div>
-                <ul className="mt-8 space-y-3">
-                  {tier.perks.map((perk) => (
-                    <li key={perk} className="flex items-start gap-3 text-sm">
-                      <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
-                      <span className="text-muted-foreground">{perk}</span>
-                    </li>
-                  ))}
-                </ul>
-                <Button
-                  className="mt-10 w-full"
-                  variant={tier.highlight ? "default" : "outline"}
-                >
-                  Quero este passaporte
-                </Button>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
 
       <section id="inscricao" className="relative py-24">
         <div className="container mx-auto px-4">

--- a/src/pages/Ingresso.tsx
+++ b/src/pages/Ingresso.tsx
@@ -2,7 +2,6 @@ import { FormEvent, Fragment } from "react";
 import {
   ArrowRight,
   Calendar,
-
   Clock,
   MapPin,
   Shield,
@@ -20,7 +19,6 @@ interface MarqueeImage {
   src: string;
   alt: string;
 }
-
 
 const marqueeImages: MarqueeImage[] = [
   {
@@ -48,7 +46,6 @@ const marqueeImages: MarqueeImage[] = [
     alt: "Equipe comemorando resultado de hackathon",
   },
 ];
-
 
 const registrationBenefits = [
   {
@@ -261,7 +258,6 @@ export default function Ingresso() {
           </div>
         </div>
       </section>
-
 
       <section id="inscricao" className="relative py-24">
         <div className="container mx-auto px-4">

--- a/src/pages/Ingresso.tsx
+++ b/src/pages/Ingresso.tsx
@@ -14,6 +14,7 @@ import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
+import SponsorsMarquee from "@/components/SponsorsMarquee";
 
 interface MarqueeImage {
   src: string;
@@ -530,6 +531,8 @@ export default function Ingresso() {
           </div>
         </div>
       </section>
+
+      <SponsorsMarquee className="py-12" title="Patrocinadores do FING" />
 
       <section id="faq" className="relative bg-muted/40 py-24">
         <div className="container mx-auto px-4">


### PR DESCRIPTION
### Purpose

Based on the conversation, the goal was to improve the user experience on the tickets page. This was achieved by adding a dynamic marquee to display event sponsors and by removing the "Passaporte" (ticket tiers) section to streamline the page content.

### Code changes

- **New Component**: Created `SponsorsMarquee.tsx`, a reusable component that displays a list of sponsors in an animated marquee.
- **New Data Source**: Added `data/sponsors.ts` to define the structure and data for the sponsors.
- **Page Refactoring (`Ingresso.tsx`)**:
    - Removed the entire "Passaporte" section that displayed different ticket tiers.
    - Imported and integrated the new `SponsorsMarquee` component to showcase the event sponsors.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c10cf1cb8990493eb306f9382d65c83a/nova-space)

👀 [Preview Link](https://c10cf1cb8990493eb306f9382d65c83a-nova-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c10cf1cb8990493eb306f9382d65c83a</projectId>-->
<!--<branchName>nova-space</branchName>-->